### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ var ModalBox = createReactClass({
     var keyboardFrame = evt.endCoordinates;
     var keyboardHeight = this.state.containerHeight - keyboardFrame.screenY;
 
-    this.state.keyboardOffset = keyboardHeight;
+    this.state.keyboardOffset = this.props.position === 'top' || keyboardHeight > 0 ? keyboardHeight : 0;
     this.animateOpen();
   },
 


### PR DESCRIPTION
a fix for resolving keyboard hide performed while editing content in Modal, in iOS, keyboardHide and keyBoardChange triggered both, the calculation of keyboard height in keyboardChange action gets a negative value which make the Modal scroll out of screen bottom.